### PR TITLE
[Bug] Adding exceptions to lint workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,7 +15,7 @@ jobs:
       run: pnpm install eslint eslint-config-react-app eslint-config-standard-with-typescript eslint-config-prettier eslint-config-airbnb prettier
     - name: Run ESLint
       working-directory: ./client
-      run: pnpm exec eslint . --ext .js --ext .ts
+      run: pnpm exec eslint . --ext .js,.ts,.tsx,.jsx
     - name: Run Prettier
       working-directory: ./client
       run: pnpm exec prettier . --check

--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -17,7 +17,7 @@
   "rules": {
     "import/extensions": 0,
     "react/jsx-filename-extension": 0,
-    "react/no-array-index-key" : 1,
+    "react/no-array-index-key": 1,
     "import/no-unresolved": 0
   }
 }

--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -14,5 +14,10 @@
     "sourceType": "module"
   },
   "plugins": ["react"],
-  "rules": {}
+  "rules": {
+    "import/extensions": 0,
+    "react/jsx-filename-extension": 0,
+    "react/no-array-index-key" : 1,
+    "import/no-unresolved": 0
+  }
 }

--- a/client/src/App.test.tsx
+++ b/client/src/App.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-undef */
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import App from "./App";


### PR DESCRIPTION
## Describe your changes

The previously implemented Lint CI workflow had certain errors when checking each file.

- Files with `.tsx` and `.jsx` extensions were not being checked.
- `Prettier` has particular options that make format checking more strict.

To correct these issues, the following additions have been made:
- Added modification to more strict rules.
- Added the `.tsx` and `.jsx`extensions to the ESLint check.

## Issue ticket number and link
N/A

## Topic
- [ ] Enhancement / New Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Test
- [ ] Breaking Change

## Supporting Docs
N/A
